### PR TITLE
Add framework for user-defined behaviors

### DIFF
--- a/blossom/data_io.py
+++ b/blossom/data_io.py
@@ -72,7 +72,12 @@ class DatasetIO(object):
             field_names (list): Organism attributes to write (per organism)
                 to file.
         """
-        organism_dict_list = [vars(organism) for organism in organism_list]
+        organism_dict_list = []
+        for organism in organism_list:
+            organism_dict = vars(organism)
+            # Ensure we're not trying to serialize the loaded modules themselves
+            del organism_dict['custom_modules']
+            organism_dict_list.append(organism_dict)
         with open(fn, 'w') as f:
             json.dump(organism_dict_list, f, indent=2)
 
@@ -137,7 +142,7 @@ class ParameterIO():
 
         return World(world_dict)
 
-    def load_species_parameters(fns, init_world):
+    def load_species_parameters(fns, init_world, custom_methods_fns):
         """
         Load all available species parameter files.
         filenames can be a single string or a list of strings.
@@ -222,6 +227,9 @@ class ParameterIO():
                     if val == 'None':
                         val = None
                     organism_dict[key] = val
+
+            # Track custom method file paths
+            organism_dict['custom_methods_fns'] = custom_methods_fns
 
             # Generate all organisms
             for i in range(organism_dict['population_size']):

--- a/blossom/fields.py
+++ b/blossom/fields.py
@@ -17,6 +17,8 @@ specific_organism_field_names = {'organism_id': None,
                         'cause_of_death': None,
                         'position': [0],
                         'sex': None,
+                        'ancestry': [],
+                        'custom_methods_fns': None,
                         'water_current': None,
                         'time_without_water': 0,
                         'food_current': None,
@@ -42,4 +44,5 @@ species_field_names = {'species_name': 'species1',
                         'water_metabolism': None,
                         'water_intake': None}
 
+# Combine organism and species field names
 organism_field_names = dict(specific_organism_field_names, **species_field_names)

--- a/blossom/universe.py
+++ b/blossom/universe.py
@@ -15,18 +15,20 @@ class Universe(object):
 
     def __init__(self,
                  world_fn=None,
-                 organism_fns=None,
+                 organisms_fn=None,
                  world_param_fn=None,
                  species_param_fns=None,
+                 custom_methods_fns=None,
                  current_time=0,
                  end_time=10,
                  dataset_dir='datasets/',
                  pad_zeroes=4,
                  file_extension='.txt'):
+        self.world_fn = world_fn
+        self.organisms_fn = organisms_fn
         self.world_param_fn = world_param_fn
         self.species_param_fns = species_param_fns
-        self.world_fn = world_fn
-        self.organism_fns = organism_fns
+        self.custom_methods_fns = custom_methods_fns
 
         self.current_time = current_time
         self.end_time = end_time
@@ -40,7 +42,7 @@ class Universe(object):
             if e.errno != errno.EEXIST:
                 raise
         self.pad_zeroes = pad_zeroes
-        while (self.end_time - self.current_time) >= 10**self.pad_zeroes:
+        while (self.end_time - self.current_time) >= 10 ** self.pad_zeroes:
             self.pad_zeroes += 1
         self.file_extension = file_extension
 
@@ -67,12 +69,12 @@ class Universe(object):
     def initialize_organisms(self):
         # organisms is a list of Organism objects
         # organisms = []
-        if self.organism_fns is not None:
+        if self.organisms_fn is not None:
             # Set up all organisms based on organism records
-            organism_list = DIO.load_organism_dataset(self.organism_fns)
+            organism_list = DIO.load_organism_dataset(self.organisms_fn)
         elif self.species_param_fns is not None:
             # Set up all organisms based on species specifications
-            organism_list = PIO.load_species_parameters(self.species_param_fns, self.world)
+            organism_list = PIO.load_species_parameters(self.species_param_fns, self.world, self.custom_methods_fns)
             DIO.write_organism_dataset(organism_list, self.dataset_dir + 'organisms_ds' + str(self.current_time).zfill(self.pad_zeroes) + self.file_extension)
         else:
             sys.exit('No files specified for initialization!')

--- a/scripts/dataset_load.py
+++ b/scripts/dataset_load.py
@@ -5,14 +5,14 @@ sys.path.append(os.path.join(os.path.dirname(__file__),'..'))
 import blossom
 
 WORLD_FN = 'datasets/world_ds0010.txt'
-ORGANISM_FNS = 'datasets/organisms_ds0010.txt'
+ORGANISMS_FN = 'datasets/organisms_ds0010.txt'
 WORLD_PARAM_FN = None
 SPECIES_PARAM_FNS = None
 START_TIME = 10
 END_TIME = 20
 
 universe = blossom.Universe(world_fn=WORLD_FN,
-                            organism_fns=ORGANISM_FNS,
+                            organisms_fn=ORGANISMS_FN,
                             world_param_fn=WORLD_PARAM_FN,
                             species_param_fns=SPECIES_PARAM_FNS,
                             current_time=START_TIME,

--- a/scripts/parameter_load.py
+++ b/scripts/parameter_load.py
@@ -5,16 +5,18 @@ sys.path.append(os.path.join(os.path.dirname(__file__), '..'))
 import blossom
 
 WORLD_FN = None
-ORGANISM_FNS = None
+ORGANISMS_FN = None
 WORLD_PARAM_FN = 'world.param'
 SPECIES_PARAM_FNS = ['species1.param']
+CUSTOM_METHODS_FNS = ['sample_methods.py']
 START_TIME = 0
 END_TIME = 100
 
 universe = blossom.Universe(world_fn=WORLD_FN,
-                            organism_fns=ORGANISM_FNS,
+                            organisms_fn=ORGANISMS_FN,
                             world_param_fn=WORLD_PARAM_FN,
                             species_param_fns=SPECIES_PARAM_FNS,
+                            custom_methods_fns=CUSTOM_METHODS_FNS,
                             current_time=START_TIME,
                             end_time=END_TIME,
                             dataset_dir='datasets/test_general/')


### PR DESCRIPTION
Generalize organism behaviors so that users can define their own behaviors via external Python scripts. As long as the user specifies the Python script file path as well as the behavior name in each species parameter file, blossom will first check custom behavior scripts before built in behaviors. It makes sure to check both as long as custom scripts are provided.